### PR TITLE
회원가입 오류 수정 

### DIFF
--- a/src/main/java/com/busanit501/shoppingweb_project/service/MemberServiceImpl.java
+++ b/src/main/java/com/busanit501/shoppingweb_project/service/MemberServiceImpl.java
@@ -25,8 +25,13 @@ public class MemberServiceImpl implements MemberService {
         Member member = MemberMapper.toMemberEntity(dto, encodedPassword);
 
         // 기본 권한 세팅
-        member.setRole("ROLE_USER");
-        member.setRole("ROLE_ADMIN");
+        boolean isAdmin = false;
+
+        if (isAdmin) {
+            member.setRole("ROLE_ADMIN");
+        } else {
+            member.setRole("ROLE_USER");
+        }
 
         // 주소가 있다면 Address도 생성 후 관계 연결
         if (dto.isRegisterAddress()) {


### PR DESCRIPTION
MemberServiceImpl 파일
member.setRole("ROLE_USER");
member.setRole("ROLE_ADMIN");
setRole은 하나의 문자열만 저장해서 회원가입시 마지막에 있던 member.setRole("ROLE_ADMIN");으로 회원가입 되었음
그래서 
boolean isAdmin = false; 관리자가 아니라는 뜻을 가지고 있습니다.

if (isAdmin) {
    member.setRole("ROLE_ADMIN");
} else {
    member.setRole("ROLE_USER");
} 
isAdmin이 true 면 관리자 회원가입, 그렇지 않으면 일반 사용자 회원가입.
수정했습니다.