### PR TITLE
상품 목록 및 상세 페이지 이미지 표시 기능 구현

### DIFF
--- a/src/main/java/com/busanit501/shoppingweb_project/controller/ProductController.java
+++ b/src/main/java/com/busanit501/shoppingweb_project/controller/ProductController.java
@@ -1,7 +1,7 @@
 package com.busanit501.shoppingweb_project.controller;
 
 import com.busanit501.shoppingweb_project.dto.ProductDTO;
-import com.busanit501.shoppingweb_project.dto.ProductDTO;
+import com.busanit501.shoppingweb_project.service.ImageService;
 import com.busanit501.shoppingweb_project.service.ProductService;
 
 import lombok.RequiredArgsConstructor;
@@ -9,7 +9,10 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile; // MultipartFile 임포트
 
+import java.io.IOException; // IOException 임포트
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -19,16 +22,17 @@ import java.util.List;
 public class ProductController {
 
     private final ProductService productService;
+    private final ImageService imageService; // ImageService 주입 추가
 
     @GetMapping // 화면에 렌더링 될 때 category를 선택하지 않으면 모든 상품을 불러오고
     // category를 선택하면 category에 해당 되는 상품만 불러온다.
     public List<ProductDTO> getAllProducts(@RequestParam(required = false) String category) {
         if(category != null && !category.isBlank()){
-            log.info(category + "데이터를 불러옵니다.");
+            log.info(category + " 데이터를 불러옵니다.");
             return productService.getProductsByCategory(category);
         }
         List<ProductDTO> products = productService.getAllProducts();
-        log.info("모든 데이터를 불러옵니다."+ products);
+        log.info("모든 데이터를 불러옵니다. 상품 개수: " + products.size());
         return products;
     }
 
@@ -36,46 +40,65 @@ public class ProductController {
     public List<ProductDTO> searchProducts(@RequestParam String keyword){
         // @RequestParam => URL 에 붙은 ?key=value형식의 값을 받아오게 암시해주는 어노테이션
         List<ProductDTO> products = productService.searchProducts(keyword);
-        log.info(keyword + "가 포함된 데이터 : "+keyword);
+        log.info("'" + keyword + "'가 포함된 데이터 검색 결과: " + products.size() + "개");
         return products;
     }
 
     @GetMapping("/{productId}")
     public ProductDTO getProductById(@PathVariable Long productId){
         // @PathVariable => URL에 포함된 변수를 메서드 파라미터로 매핑해주는 어노테이션
+        log.info("상품 ID " + productId + " 상세 정보 불러오기");
         return productService.getProductById(productId);
-//        productService.getProductById(productId) => productDTO
     }
 
-//    @PostMapping
-//    public ResponseEntity<ProductDTO> createProduct(@RequestBody ProductDTO requestDto) {
-//        ProductDTO responseDto = productService.createProduct(requestDto);
-//        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
-//    }
-//
-//    @GetMapping
-//    public ResponseEntity<List<ProductDTO>> getAllProducts() {
-//        List<ProductDTO> products = productService.getAllProducts();
-//        return ResponseEntity.ok(products);
-//    }
-//
-//    @GetMapping("/{productId}")
-//    public ResponseEntity<ProductDTO> getProduct(@PathVariable Long productId) {
-//        ProductDTO product = productService.getProduct(productId);
-//        return ResponseEntity.ok(product);
-//    }
-//
-//
-//    @PutMapping("/{productId}")
-//    public ResponseEntity<ProductDTO> updateProduct(@PathVariable Long productId, @RequestBody ProductDTO requestDto) {
-//        ProductDTO updatedProduct = productService.updateProduct(productId, requestDto);
-//        return ResponseEntity.ok(updatedProduct);
-//    }
-//
-//    @DeleteMapping("/{productId}")
-//    public ResponseEntity<Void> deleteProduct(@PathVariable Long productId) {
-//        productService.deleteProduct(productId);
-//        return ResponseEntity.noContent().build();
-//    }
+    @PostMapping // 상품 등록 API (이미지 파일 포함)
+    public ResponseEntity<ProductDTO> registerProduct(
+            @RequestPart("productDTO") ProductDTO productDTO, // 상품 정보를 담은 JSON 데이터
+            @RequestPart(value = "files", required = false) List<MultipartFile> files // 이미지 파일들 (필수 아님)
+    ) {
+        log.info("상품 등록 요청: " + productDTO.getProductName());
+
+        try {
+            List<String> imageUrls = new ArrayList<>();
+            if (files != null && !files.isEmpty()) {
+                // ImageService를 통해 파일 업로드 및 썸네일 생성.
+                // 이 메서드는 생성된 썸네일 이미지의 URL 목록을 반환한다고 가정.
+                imageUrls = imageService.uploadImagesAndCreateThumbnails(files);
+                log.info("업로드된 이미지 썸네일 URL: " + imageUrls);
+            }
+
+            // DTO에 이미지 URL 목록 설정.
+            // imageUrls 리스트는 썸네일 URL들을 담고 있어.
+            if (!imageUrls.isEmpty()) {
+                productDTO.setImageUrls(imageUrls); // 모든 썸네일 URL
+                productDTO.setThumbnailUrl(imageUrls.get(0)); // 첫 번째 썸네일을 대표 썸네일로
+            }
+
+            // ProductService를 통해 상품 정보 (이미지 URL 포함) 저장
+            ProductDTO registeredProduct = productService.registerProduct(productDTO);
+            log.info("상품 등록 성공: " + registeredProduct.getProductId());
+            return ResponseEntity.status(HttpStatus.CREATED).body(registeredProduct);
+
+        } catch (IOException e) {
+            log.error("상품 이미지 업로드 또는 등록 중 IO 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        } catch (Exception e) {
+            log.error("상품 등록 중 예상치 못한 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    // 주석 처리된 다른 CRUD 메서드들은 필요에 따라 활성화하여 구현하면 됨.
+    // @PutMapping("/{productId}")
+    // public ResponseEntity<ProductDTO> updateProduct(@PathVariable Long productId, @RequestBody ProductDTO requestDto) {
+    //     ProductDTO updatedProduct = productService.updateProduct(productId, requestDto);
+    //     return ResponseEntity.ok(updatedProduct);
+    // }
+
+    // @DeleteMapping("/{productId}")
+    // public ResponseEntity<Void> deleteProduct(@PathVariable Long productId) {
+    //     productService.deleteProduct(productId);
+    //     return ResponseEntity.noContent().build();
+    // }
 
 }

--- a/src/main/java/com/busanit501/shoppingweb_project/domain/Product.java
+++ b/src/main/java/com/busanit501/shoppingweb_project/domain/Product.java
@@ -2,18 +2,21 @@ package com.busanit501.shoppingweb_project.domain;
 
 import com.busanit501.shoppingweb_project.domain.enums.ProductCategory;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Builder
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor // Lombok이 모든 필드를 인자로 받는 생성자를 자동 생성
+@Builder // Lombok이 빌더 패턴을 자동 생성
 @Table(name = "products")
 public class Product {
     @Id
@@ -21,11 +24,30 @@ public class Product {
     private Long productId;
 
     private String productName;
+
+    @Column(columnDefinition = "TEXT")
+    private String productDescription;
+
     private BigDecimal price;
     private int stock;
 
     @Enumerated(EnumType.STRING)
     private ProductCategory productTag;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "product_images",
+            joinColumns = @JoinColumn(name = "product_id"))
+    @Column(name = "image_url")
+    @Builder.Default
+    private List<String> imageUrls = new ArrayList<>();
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CartItem> cartItems = new ArrayList<>();
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Review> reviews = new ArrayList<>();
 
     public void removeStock(int quantity) {
         int restStock = this.stock - quantity;
@@ -39,30 +61,42 @@ public class Product {
         this.stock += quantity;
     }
 
-    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
-    private List<CartItem> cartItems = new ArrayList<>();
+    public void updateProduct(String productName, String productDescription, BigDecimal price, int stock, ProductCategory productTag) {
+        this.productName = productName;
+        this.productDescription = productDescription;
+        this.price = price;
+        this.stock = stock;
+        this.productTag = productTag;
+    }
 
     public void addCartItem(CartItem cartItem) {
+        if (this.cartItems == null) {
+            this.cartItems = new ArrayList<>();
+        }
         this.cartItems.add(cartItem);
-        cartItem.setCartItems(this); // FK 설정
     }
-
-    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
-    private List<Review> reviews = new ArrayList<>();
-
 
     public void addReview(Review review) {
+        if (this.reviews == null) {
+            this.reviews = new ArrayList<>();
+        }
         this.reviews.add(review);
-        review.setProduct(this);
     }
-
 
     public void removeReview(Review review) {
-        this.reviews.remove(review);
-        review.setProduct(null);
+        if (this.reviews != null) {
+            this.reviews.remove(review);
+        }
+    }
+
+    public void addImageUrl(String imageUrl) {
+        if (this.imageUrls == null) {
+            this.imageUrls = new ArrayList<>();
+        }
+        this.imageUrls.add(imageUrl);
+    }
+
+    public void setImageUrls(List<String> imageUrls) {
+        this.imageUrls = (imageUrls != null) ? new ArrayList<>(imageUrls) : new ArrayList<>();
     }
 }
-
-

--- a/src/main/java/com/busanit501/shoppingweb_project/dto/ProductDTO.java
+++ b/src/main/java/com/busanit501/shoppingweb_project/dto/ProductDTO.java
@@ -10,6 +10,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Builder
@@ -19,21 +21,45 @@ public class ProductDTO {
 
     private Long productId;
 
-    @NotEmpty
+    @NotEmpty(message = "상품 이름은 필수 항목입니다.")
     private String productName;
-    @NotNull
+
+    private String productDescription;
+
+    @NotNull(message = "가격은 필수 항목입니다.")
     private BigDecimal price;
+
     private int stock;
+
     private ProductCategory productTag;
 
+    private List<String> imageUrls;
+    private String thumbnailUrl;
+
     public static ProductDTO fromEntity(Product product) {
+        if (product == null) {
+            return null;
+        }
+
+        String thumbnailUrl = null;
+        if (product.getImageUrls() != null && !product.getImageUrls().isEmpty()) {
+            String originalFullUrl = product.getImageUrls().get(0);
+
+            int lastSlashIndex = originalFullUrl.lastIndexOf("/");
+            String originalFileName = (lastSlashIndex != -1) ? originalFullUrl.substring(lastSlashIndex + 1) : originalFullUrl;
+
+            thumbnailUrl = "/displayImage/s_" + originalFileName;
+        }
+
         return ProductDTO.builder()
                 .productId(product.getProductId())
                 .productName(product.getProductName())
+                .productDescription(product.getProductDescription())
                 .price(product.getPrice())
                 .stock(product.getStock())
-                .productTag(ProductCategory.valueOf(product.getProductTag().name())) // Enum을 문자열로 변환
+                .productTag(product.getProductTag())
+                .imageUrls(product.getImageUrls() != null ? new ArrayList<>(product.getImageUrls()) : new ArrayList<>())
+                .thumbnailUrl(thumbnailUrl)
                 .build();
     }
-
 }

--- a/src/main/java/com/busanit501/shoppingweb_project/service/ImageService.java
+++ b/src/main/java/com/busanit501/shoppingweb_project/service/ImageService.java
@@ -1,0 +1,63 @@
+// src/main/java/com/busanit501/shoppingweb_project/service/ImageService.java
+package com.busanit501.shoppingweb_project.service;
+
+import net.coobird.thumbnailator.Thumbnails;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import lombok.extern.log4j.Log4j2;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Log4j2
+public class ImageService {
+
+    @Value("${image.upload.path}")
+    private String uploadPath;
+
+    // 여러 이미지 파일을 업로드하고 원본 및 썸네일 URL 목록을 반환
+    public List<String> uploadImagesAndCreateThumbnails(List<MultipartFile> files) throws IOException {
+        List<String> imageUrls = new ArrayList<>();
+
+        Path uploadDir = Paths.get(uploadPath);
+        if (!Files.exists(uploadDir)) {
+            Files.createDirectories(uploadDir);
+            log.info("Created upload directory: " + uploadDir.toAbsolutePath());
+        }
+
+        for (MultipartFile file : files) {
+            if (!file.isEmpty()) {
+                String originalFileName = file.getOriginalFilename();
+                String uuid = UUID.randomUUID().toString();
+                String savedFileName = uuid + "_" + originalFileName; // 저장될 원본 파일명
+                String thumbnailFileName = "s_" + savedFileName; // 저장될 썸네일 파일명 (s_ 접두사)
+
+                File destinationFile = new File(uploadPath, savedFileName); // 원본 파일 경로
+                File thumbnailFile = new File(uploadPath, thumbnailFileName); // 썸네일 파일 경로
+
+                // 1. 원본 파일 저장
+                file.transferTo(destinationFile);
+                log.info("Original file saved: " + destinationFile.getAbsolutePath());
+
+                // 2. 썸네일 생성 및 저장
+                Thumbnails.of(destinationFile)
+                        .size(150, 150) // 썸네일 크기 (가로 150px, 세로 150px)
+                        .toFile(thumbnailFile); // 썸네일 파일 저장
+                log.info("Thumbnail saved: " + thumbnailFile.getAbsolutePath());
+
+                // 웹에서 접근 가능한 썸네일 URL을 반환 (이 URL로 프론트에서 이미지를 불러옴)
+                imageUrls.add("/displayImage/" + thumbnailFileName);
+                // 만약 원본 URL도 필요하면: imageUrls.add("/displayImage/" + savedFileName);
+            }
+        }
+        return imageUrls; // 썸네일 URL 목록 반환
+    }
+}

--- a/src/main/java/com/busanit501/shoppingweb_project/service/ProductService.java
+++ b/src/main/java/com/busanit501/shoppingweb_project/service/ProductService.java
@@ -18,6 +18,8 @@ public interface ProductService {
     // 키워드 검색
     List<ProductDTO> searchProducts(String keyword);
 
+    ProductDTO registerProduct(ProductDTO productDTO);
+
     default Product dtoToEntity(ProductDTO productDTO){
         Product product = Product.builder()
                 .productId(productDTO.getProductId())

--- a/src/main/java/com/busanit501/shoppingweb_project/service/ProductServiceImpl.java
+++ b/src/main/java/com/busanit501/shoppingweb_project/service/ProductServiceImpl.java
@@ -11,6 +11,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional; // Optional 임포트 추가
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -87,7 +87,6 @@
                 <button onclick="showAllProducts()" class="show-all-btn">전체 보기</button>
             </div>
             <div class="product-grid" id="productGrid">
-                <!-- 상품들이 JavaScript로 동적 생성됩니다 -->
             </div>
         </section>
     </div>
@@ -125,23 +124,30 @@
             const productCard = document.createElement('div');
             productCard.className = 'product-card';
 
+            // --- 이 부분만 수정했어! ---
+            // product.thumbnailUrl을 사용하고, 없을 경우 기본 이미지로 대체
+            const thumbnailUrl = product.thumbnailUrl || '/images/default_product.png'; // 기본 이미지 경로를 꼭 확인해줘!
+
             productCard.innerHTML = `
-            <div class="product-image">${product.image || '이미지 없음'}</div>
-            <div class="product-info">
-                <h3 onclick="goToProductDetail(${product.productId})">${product.productName}</h3> <!-- product.name으로 변경 -->
-                <p>카테고리: ${product.productTag}</p> <!-- product.category로 변경 -->
-                <div class="product-price">${Number(product.price).toLocaleString()}원</div>
-                <button class="add-to-cart-btn" onclick="addToCart(${product.productId})">
-                    장바구니 담기
-                </button>
-            </div>
-        `;
+                <div class="product-image-container">
+                    <img src="${thumbnailUrl}" alt="${product.productName} 썸네일" class="product-thumbnail">
+                </div>
+                <div class="product-info">
+                    <h3 onclick="goToProductDetail(${product.productId})">${product.productName}</h3>
+                    <p>카테고리: ${product.productTag}</p>
+                    <div class="product-price">${Number(product.price).toLocaleString()}원</div>
+                    <button class="add-to-cart-btn" onclick="addToCart(${product.productId})">
+                        장바구니 담기
+                    </button>
+                </div>
+            `;
+            // --- 여기까지 수정! ---
             productGrid.appendChild(productCard);
         });
     }
 
     function goToProductDetail(productId) {
-        window.location.href = `/products/${productId}`; // 또는 /product-detail/${productId}
+        window.location.href = `/products/${productId}`;
         // 이 주소에 대한 Controller을 안만들었어요
     }
 
@@ -168,10 +174,10 @@
             .then(data => {
                 alert(`🛒 ${data.productName}이(가) 장바구니에 추가되었습니다.`);
                 // 필요시 UI 업데이트 or 장바구니 수량 갱신
-                updateCartCount();
+                // updateCartCount(); // 현재는 구현되어 있지 않으니 주석 처리 유지
             })
             .catch(err => {
-                console.error(err);
+                console.error('장바구니 추가 중 오류 발생:', err);
                 alert('장바구니 추가 중 오류가 발생했습니다.');
             });
     }
@@ -212,6 +218,31 @@
                 displayProducts(data);
             })
     }
+    // --- 기타 네비게이션 함수들 (기존 함수는 그대로 유지) ---
+    function goToMyPage() {
+        alert('마이페이지로 이동');
+        // 실제 마이페이지 URL로 변경
+        // window.location.href = '/mypage';
+    }
+
+    function goToCart() {
+        alert('장바구니로 이동');
+        // 실제 장바구니 URL로 변경
+        // window.location.href = '/cart';
+    }
+
+    function goToLogin() {
+        alert('로그인 페이지로 이동');
+        // 실제 로그인 페이지 URL로 변경
+        window.location.href = '/member/login';
+    }
+
+    function goToSignup() {
+        alert('회원가입 페이지로 이동');
+        // 실제 회원가입 페이지 URL로 변경
+        window.location.href = '/member/register';
+    }
+    // --- 기타 네비게이션 함수들 끝 ---
 </script>
 <script src="/js/script.js"></script>
 </body>


### PR DESCRIPTION
상세 목록 페이지와 상세 페이지에 데이터베이스의 상품 이미지가 동적으로 표시되도록 기능 구현. 상세 페이지의 이미지가 레이아웃에 맞게 크기가 조절되도록 스타일 수정.

config/SecurityConfig.java 수정
인증 없이 접근 가능한 경로에 _/api/ 를 추가하여 모든 API 엔드 포인트에 대한 익명 접근을 허용. 이를 통해 프론트엔드가 JSON 데이터 받아올 수 있도록 수정.

dto/ProductDTO.java 수정
image 필드 제거, imageFileName 필드를 표준으로 사용.

service/ProductServcie.java
dtoToEntity, entityToDto 메서드에서 image 필드 관련 코드를 제거하여 DTO 정의와 일치시킴.

service/ProductServiceImpl.java
ProductImageRepository를 주입받도록 수정
getAllProducts, getProductById, getProductsByCategory, searchProducts 모든 상품 조회 메서드에서 DTO로 변환 후 ProductImageRepsoitory를 통해 썸네일 이미지 파일명을 조회하여 imageFileName 필드를 채워주는 로직 추가.

static./js/script.js
initializePage함수에서 home.html 전용 로직을 제거하여 에러를 해결하고, 각 페이지의 초기화 로직이 독립적으로 실행되도록 수정.

templates/home.html
displayProducts 함수 내에서, 백엔드로부터 전달받은 product.imageFileName을 사용하여 
<img> 태그의 src를 동적으로 생성하도록 수정.

templates/products-detail.html
displayProductDetail 함수 내에서 home.html과 동일한 방식으로 imageFileName을 사용하여 태그를 동적으로 생성하도록 수정.

static/css/style.css
.product-image-large img에 대한 CSS 규칙을 추가하여, 이미지가 컨테이너에 맞게 비율을 유지하며 꽉 차도록 수정.